### PR TITLE
Testes de Evolução Neuropsicológica: criar, ver e editar [#175305991][#175306141][#175306051]

### DIFF
--- a/Saudox/app/Http/Controllers/AgendamentosController.php
+++ b/Saudox/app/Http/Controllers/AgendamentosController.php
@@ -121,7 +121,7 @@ class AgendamentosController extends Controller {
 
         $prof_logado = Profissional::find(Auth::id());
         if(!$prof_logado->podeCriarAgendamento() ||
-            $agendamento->id_profissional != $prof_logado->id {
+            $agendamento->id_profissional != $prof_logado->id) {
 
             return view('erro', ['msg_erro' => "Você não tem permissão para realizar essa ação!"]);
         }

--- a/Saudox/app/Http/Controllers/Profissional/ProfissionalEvolucaoController.php
+++ b/Saudox/app/Http/Controllers/Profissional/ProfissionalEvolucaoController.php
@@ -162,6 +162,11 @@ class ProfissionalEvolucaoController extends Controller {
             return redirect()->route('erro', ['msg_erro' => "Evolução não existe"]);
         }
 
+        $profissional_logado = Auth::user();
+        if(!$profissional_logado->ehAdmin() && $evolucao->id_profissional != $profissional_logado->id) {
+            return redirect()->route('erro', ['msg_erro' => "Você não tem permissão para acessar essa página."]);
+        }
+
         $evolucao->dia_evolucao = date_format(date_create($evolucao->data_evolucao), 'Y-m-d');
         $evolucao->hora_evolucao = date_format(date_create($evolucao->data_evolucao), 'H:i');
 
@@ -189,6 +194,10 @@ class ProfissionalEvolucaoController extends Controller {
             return redirect()->route('erro', ['msg_erro' => "Evolução não existe"]);
         }
 
+        $profissional_logado = Auth::user();
+        if(!$profissional_logado->ehAdmin() || $evolucao->id_profissional != $profissional_logado->id) {
+            return redirect()->route('erro', ['msg_erro' => "Você não tem permissão para acessar essa página"]);
+        }
 
         $validator_evo_psico = Validator::make($entrada, EvolucaoPsicologica::$regras_validacao_editar, $messages);
         if ($validator_evo_psico->fails()) {

--- a/Saudox/app/Http/Controllers/Profissional/ProfissionalEvolucaoController.php
+++ b/Saudox/app/Http/Controllers/Profissional/ProfissionalEvolucaoController.php
@@ -84,7 +84,7 @@ class ProfissionalEvolucaoController extends Controller {
     public function verNeuropsicologia($id_paciente) {
 
         $profissional_logado = Auth::user();
-        if(!$profissional_logado->podeCriarEvolucao()) {
+        if(!$profissional_logado->podeCriarPaciente()) {
             return redirect()->route('erro', ['msg_erro' => "Você não pode visualizar essa página"]);
         }
 

--- a/Saudox/app/Http/Controllers/Profissional/ProfissionalEvolucaoController.php
+++ b/Saudox/app/Http/Controllers/Profissional/ProfissionalEvolucaoController.php
@@ -82,6 +82,12 @@ class ProfissionalEvolucaoController extends Controller {
 
     // NEUROPSICOLOGIA
     public function verNeuropsicologia($id_paciente) {
+
+        $profissional_logado = Auth::user();
+        if(!$profissional_logado->podeCriarEvolucao()) {
+            return redirect()->route('erro', ['msg_erro' => "Você não pode visualizar essa página"]);
+        }
+
         $paciente = Paciente::find($id_paciente);
         if(!$paciente){
             return redirect()->route('erro', ['msg_erro' => "Paciente " .$id_paciente. " inexistente"]);
@@ -114,6 +120,11 @@ class ProfissionalEvolucaoController extends Controller {
 
 
     public function salvarNeuropsicologia(Request $request) {
+
+        $profissional_logado = Auth::user();
+        if(!$profissional_logado->podeCriarEvolucao()) {
+            return redirect()->route('erro', ['msg_erro' => "Você não pode visualizar essa página"]);
+        }
 
         $messages = [
             'required' => 'O campo :attribute é obrigatório.',

--- a/Saudox/app/Profissional.php
+++ b/Saudox/app/Profissional.php
@@ -33,7 +33,6 @@ class Profissional extends Authenticatable {
 
     const ProfissoesQuePodemCriarPacientes = [
         self::Adm,
-        self::Recepcionista,
         self::Fonoaudiologo,
         self::TerapeutaOcupacional,
         self::Neuropsicologo,

--- a/Saudox/database/factories/Evolucao_psicologicaFactory.php
+++ b/Saudox/database/factories/Evolucao_psicologicaFactory.php
@@ -25,6 +25,5 @@ $factory->define(EvolucaoPsicologica::class, function (Faker $faker) {
         'data_evolucao' => Carbon::now()->format('Y-m-d H:i:s'),
         'tipo_atendimento' => '9',
         'texto' => 'asfohasofuhsaoufhasoufhasioufhsa kfukxzgfuisagfaiufas',
-
     ];
 });

--- a/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
+++ b/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
@@ -153,7 +153,7 @@ class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
             ), $this->password);
         $prof_aux = $criarProf_Logar['profissional'];
 
-        $evolucao = factory(EvolucaoPsicologica::class)->create([
+        factory(EvolucaoPsicologica::class)->create([
             'id_paciente' => $this->paciente->id,
             'id_profissional' => $prof_aux->id,
             'texto' => "texto de teste",
@@ -174,7 +174,6 @@ class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
             array(
                 Profissional::Recepcionista,
             ), $this->password);
-        $prof_aux = $criarProf_Logar['profissional'];
 
         $evolucao = factory(EvolucaoPsicologica::class)->create([
             'id_paciente' => $this->paciente->id,

--- a/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
+++ b/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
@@ -175,7 +175,7 @@ class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
                 Profissional::Recepcionista,
             ), $this->password);
 
-        $evolucao = factory(EvolucaoPsicologica::class)->create([
+        factory(EvolucaoPsicologica::class)->create([
             'id_paciente' => $this->paciente->id,
             'id_profissional' => $this->profissional->id,
             'texto' => "texto de teste",
@@ -241,7 +241,6 @@ class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
             array(
                 Profissional::Recepcionista,
             ), $this->password);
-        $prof_aux = $criarProf_Logar['profissional'];
 
         $evolucao = factory(EvolucaoPsicologica::class)->create([
             'id_paciente' => $this->paciente->id,

--- a/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
+++ b/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Endereco;
+use App\Profissional;
+use App\Paciente;
+
+use Illuminate\Support\Facades\Auth;
+
+class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
+    public $profissional;
+    private $endereco;
+    private $paciente;
+
+    public function setUp() : void {
+        parent::setUp();
+
+        $this->password = '123123123';
+        $this->password_encrypt = bcrypt($this->password);
+
+        $this->endereco = factory(Endereco::class)->create();
+        $this->paciente = factory(Paciente::class)->create([
+            'password' => $this->password_encrypt,
+            'id_endereco' => $this->endereco->id,
+        ]);
+        $this->profissional = factory(Profissional::class)->create([
+            'password' => $this->password_encrypt,
+            'profissao' => Profissional::Adm,
+        ]);
+
+        // Array extendido da superclasse
+        $this->array_evo_neuro = $this->evolucao_neuropsicologica;
+        $this->array_evo_neuro['id_paciente'] = $this->paciente->id;
+        $this->array_evo_neuro['id_profissional'] = $this->profissional->id;
+    }
+
+    // Função que cria um profissional e já loga ele.
+    // O parametro $profissoes é um array de profissoes
+    public function criarProfELogar($profissoes, $password) {
+        // Concatenação das profissões com ';'
+        $str_profissoes = '';
+        foreach($profissoes as $p) {
+            $str_profissoes = $str_profissoes . $p . ";";
+        }
+        // Criação do profissional
+        $prof_aux = factory(Profissional::class)->create([
+            'password' => bcrypt($password),
+            'profissao' => $str_profissoes,
+        ]);
+
+        // Login
+        $resposta_login = $this->post(route("profissional.login"), [
+             'login' => $prof_aux->login,
+             'password' => $password,
+        ]);
+
+        // Login teste
+        Auth::login($prof_aux, true);
+        $this->assertTrue(Auth::check());
+        // Ao fazer login ele é redirecionado para a home (fazendo verificação)
+        $resposta_login->assertRedirect(route("profissional.home"));
+
+        // Retorna o profissional criado e o resultado do login
+        return ['profissional' => $prof_aux, 'resposta_login' => $resposta_login];
+    }
+
+    /** @test **/
+    /* url: https://www.pivotaltracker.com/story/show/175305991 */
+    /* TA_01 */
+    public function profissionalPodeAcessarACriacaoEvolucaoNeuropsicologica() {
+        // Gera um profissional com as profissões indicadas e realiza o login
+        $criarProf_Logar = $this->criarProfELogar(
+            array(
+                Profissional::Neuropsicologo,
+                Profissional::Adm,
+            ), $this->password);
+        $criarProf_Logar['profissional'];
+
+        // Gera um novo paciente (sem evolucao)
+        $paciente_aux = factory(Paciente::class)->create([
+            'password' => $this->password_encrypt,
+            'id_endereco' => $this->endereco->id,
+        ]);
+
+        // Verifica se pode acessar a área de criação de evolução
+        $resposta_ver_criar_evo_neuro = $this->get(route("profissional.evolucao.neuropsicologica.criar", ['id_paciente' => $paciente_aux->id]));
+        $resposta_ver_criar_evo_neuro->assertSee("atendimento");
+    }
+
+    /** @test **/
+    /* url: https://www.pivotaltracker.com/story/show/175305991 */
+    /* TA_02 */
+    public function profissionalPodeCriarEvolucaoNeuropsicologica() {
+        // Gera um profissional com as profissões indicadas e realiza o login
+        $criarProf_Logar = $this->criarProfELogar(
+            array(
+                Profissional::Neuropsicologo,
+                Profissional::Adm,
+            ), $this->password);
+        $prof_aux = $criarProf_Logar['profissional'];
+
+        // Gera uma cópia da evolução da Factory, indicando os ids
+        $copia_evolucao = $this->array_evo_neuro;
+        $copia_evolucao['id_paciente'] = $this->paciente->id;
+        $copia_evolucao['id_profissional'] = $prof_aux->id;
+        $copia_evolucao['texto'] = 'texto de teste';
+
+        // Cria a $resposta_ver_evo_neuro
+        $res = $this->post(route("profissional.evolucao.neuropsicologica.salvar", $copia_evolucao));
+        $res->assertSessionHasNoErrors();
+
+        // Verifica se a evolução agora existe
+        $resposta_ver_evo_neuro = $this->get(route("profissional.evolucao.neuropsicologica.ver", ['id_paciente' => $this->paciente->id]));
+        $resposta_ver_evo_neuro->assertSee("texto de teste");
+    }
+
+
+    /** @test **/
+    /* url: https://www.pivotaltracker.com/story/show/175305991 */
+    /* TA_03 */
+    public function profissionalNAOPodeCriarEvolucaoNeuropsicologicaCamposVazios() {
+        // Gera um profissional com as profissões indicadas e realiza o login
+        $criarProf_Logar = $this->criarProfELogar(
+            array(
+                Profissional::Neuropsicologo,
+                Profissional::Adm,
+            ), $this->password);
+        $prof_aux = $criarProf_Logar['profissional'];
+
+        // Gera uma cópia da evolução da Factory, indicando os ids
+        $copia_evolucao = $this->array_evo_neuro;
+        $copia_evolucao['id_paciente'] = $this->paciente->id;
+        $copia_evolucao['id_profissional'] = $prof_aux->id;
+        $copia_evolucao['hora_evolucao'] = '';
+
+        // Cria a $resposta_ver_evo_neuro
+        $res = $this->post(route("profissional.evolucao.neuropsicologica.salvar", $copia_evolucao));
+        $res->assertSessionHasErrors();
+    }
+
+}

--- a/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
+++ b/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
@@ -170,7 +170,7 @@ class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
     /* TA_02 */
     public function profissionalSemPermissaoNaoPodeAcessarVerEvolucaoNeuro() {
         // Gera um profissional com as profissões indicadas e realiza o login
-        $criarProf_Logar = $this->criarProfELogar(
+        $this->criarProfELogar(
             array(
                 Profissional::Recepcionista,
             ), $this->password);
@@ -237,7 +237,7 @@ class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
     /* TA_03 */
     public function profissionalSemPermissaoNaoPodeEditarVerEvolucaoNeuro() {
         // Gera um profissional com as profissões indicadas e realiza o login
-        $criarProf_Logar = $this->criarProfELogar(
+        $this->criarProfELogar(
             array(
                 Profissional::Recepcionista,
             ), $this->password);

--- a/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
+++ b/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
@@ -165,5 +165,29 @@ class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
     }
 
 
+    /** @test **/
+    /* url: https://www.pivotaltracker.com/story/show/175306141 */
+    /* TA_02 */
+    public function profissionalSemPermissaoNaoPodeAcessarVerEvolucaoNeuro() {
+        // Gera um profissional com as profissões indicadas e realiza o login
+        $criarProf_Logar = $this->criarProfELogar(
+            array(
+                Profissional::Recepcionista,
+            ), $this->password);
+        $prof_aux = $criarProf_Logar['profissional'];
+
+        $evolucao = factory(EvolucaoPsicologica::class)->create([
+            'id_paciente' => $this->paciente->id,
+            'id_profissional' => $this->profissional,
+            'texto' => "texto de teste",
+        ]);
+
+        // Verifica a evolução
+        $resposta_ver_evo_neuro = $this->get(route("profissional.evolucao.neuropsicologica.ver", ['id_paciente' => $this->paciente->id]));
+        // Verifica que NÃO  está vendo o cmapo que tentou criar
+        $resposta_ver_evo_neuro->assertDontSee("texto de teste");
+    }
+
+
 
 }

--- a/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
+++ b/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
@@ -178,7 +178,7 @@ class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
 
         $evolucao = factory(EvolucaoPsicologica::class)->create([
             'id_paciente' => $this->paciente->id,
-            'id_profissional' => $this->profissional,
+            'id_profissional' => $this->profissional->id,
             'texto' => "texto de teste",
         ]);
 
@@ -189,5 +189,71 @@ class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
     }
 
 
+    /** @test **/
+    /* url: https://www.pivotaltracker.com/story/show/175306051 */
+    /* TA_01 */
+    public function profissionalComPermissaoPodeEditarVerEvolucaoNeuro() {
+        // Gera um profissional com as profissões indicadas e realiza o login
+        $criarProf_Logar = $this->criarProfELogar(
+            array(
+                Profissional::Neuropsicologo,
+            ), $this->password);
+        $prof_aux = $criarProf_Logar['profissional'];
+
+        $evolucao = factory(EvolucaoPsicologica::class)->create([
+            'id_paciente' => $this->paciente->id,
+            'id_profissional' => $prof_aux->id,
+            'texto' => "texto de teste",
+        ]);
+
+        // Verifica a evolução
+        $resposta_ver_evo_neuro = $this->get(route("profissional.evolucao.neuropsicologica.editar", ['id_evolucao' => $evolucao->id]));
+        $resposta_ver_evo_neuro->assertSee("texto de teste");
+    }
+
+    /** @test **/
+    /* url: https://www.pivotaltracker.com/story/show/175306051 */
+    /* TA_02 */
+    public function profissionalAdminPodeEditarVerEvolucaoNeuro() {
+        // Gera um profissional com as profissões indicadas e realiza o login
+        $criarProf_Logar = $this->criarProfELogar(
+            array(
+                Profissional::Adm,
+            ), $this->password);
+        $prof_aux = $criarProf_Logar['profissional'];
+
+        $evolucao = factory(EvolucaoPsicologica::class)->create([
+            'id_paciente' => $this->paciente->id,
+            'id_profissional' => $prof_aux->id,
+            'texto' => "texto de teste",
+        ]);
+
+        // Verifica a evolução
+        $resposta_ver_evo_neuro = $this->get(route("profissional.evolucao.neuropsicologica.editar", ['id_evolucao' => $evolucao->id]));
+        $resposta_ver_evo_neuro->assertSee("texto de teste");
+    }
+
+    /** @test **/
+    /* url: https://www.pivotaltracker.com/story/show/175306051 */
+    /* TA_03 */
+    public function profissionalSemPermissaoNaoPodeEditarVerEvolucaoNeuro() {
+        // Gera um profissional com as profissões indicadas e realiza o login
+        $criarProf_Logar = $this->criarProfELogar(
+            array(
+                Profissional::Recepcionista,
+            ), $this->password);
+        $prof_aux = $criarProf_Logar['profissional'];
+
+        $evolucao = factory(EvolucaoPsicologica::class)->create([
+            'id_paciente' => $this->paciente->id,
+            'id_profissional' => $this->profissional,
+            'texto' => "texto de teste",
+        ]);
+
+        // Verifica a evolução
+        $resposta_ver_evo_neuro = $this->get(route("profissional.evolucao.neuropsicologica.editar", ['id_evolucao' => $evolucao->id]));
+        // Verifica que NÃO  está vendo o cmapo que tentou criar
+        $resposta_ver_evo_neuro->assertDontSee("texto de teste");
+    }
 
 }

--- a/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
+++ b/Saudox/tests/Feature/Profissional_EvolucaoNeuropsicologicaTest.php
@@ -6,6 +6,7 @@ use Tests\TestCase;
 use App\Endereco;
 use App\Profissional;
 use App\Paciente;
+use App\EvolucaoPsicologica;
 
 use Illuminate\Support\Facades\Auth;
 
@@ -139,5 +140,30 @@ class Profissional_EvolucaoNeuropsicologicaTest extends TestCase {
         $res = $this->post(route("profissional.evolucao.neuropsicologica.salvar", $copia_evolucao));
         $res->assertSessionHasErrors();
     }
+
+
+    /** @test **/
+    /* url: https://www.pivotaltracker.com/story/show/175306141 */
+    /* TA_01 */
+    public function profissionalPodeAcessarVisualizacaoEvolucaoNeuro() {
+        // Gera um profissional com as profissões indicadas e realiza o login
+        $criarProf_Logar = $this->criarProfELogar(
+            array(
+                Profissional::Neuropsicologo,
+            ), $this->password);
+        $prof_aux = $criarProf_Logar['profissional'];
+
+        $evolucao = factory(EvolucaoPsicologica::class)->create([
+            'id_paciente' => $this->paciente->id,
+            'id_profissional' => $prof_aux->id,
+            'texto' => "texto de teste",
+        ]);
+
+        // Verifica se a evolução
+        $resposta_ver_evo_neuro = $this->get(route("profissional.evolucao.neuropsicologica.ver", ['id_paciente' => $this->paciente->id]));
+        $resposta_ver_evo_neuro->assertSee("texto de teste");
+    }
+
+
 
 }

--- a/Saudox/tests/TestCase.php
+++ b/Saudox/tests/TestCase.php
@@ -234,6 +234,16 @@ abstract class TestCase extends BaseTestCase {
             'info_extras_relevante' => 'asofugasoufgsafgasçiufgasuifgasuifgasuf',
         ];
 
+        $this->evolucao_neuropsicologica = [
+            'id_paciente' => 0,
+            'id_profissional' => 0,
+            'id_evolucao_anterior' => null, //rand(1,$qtd_evolucao_psicologicas),
+            'dia_evolucao' => "2020-10-28",
+            'hora_evolucao' => '06:06',
+            'tipo_atendimento' => '9',
+            'texto' => 'asfohasofuhsaoufhasoufhasioufhsa kfukxzgfuisagfaiufas',
+        ];
+
     }
 
 }


### PR DESCRIPTION
### Todos os testes referentes a Evolução Neuropsicolígica
__Como documentado no pivotaltracker:__
- Profissional tem acesso a página de criação de evolução neuropsicológica de um paciente 
- Profissional poderá criar evoluções com sucesso
- Profissional não conseguirá criar evoluções sem preencher os campos obrigatórios
- Os profissionais que tem permissão de criar paciente (um conjunto restrito de profissões) poderão as evoluções de neuro.
- Os profissionais que não tem permissão de criar paciente (um conjunto restrito de profissões) não poderão as evoluções de neuro.
- O profissional que criou a evolução poderá editá-la
- O admin poderá editar qualquer evolução
- Profissionais que não são admin e que não são os responsáveis pela criação de uma dada evolução, não poderão editá-la